### PR TITLE
refactor(MapInfo): remove `maxScore`

### DIFF
--- a/packages/osu-base/src/tools/MapInfo.ts
+++ b/packages/osu-base/src/tools/MapInfo.ts
@@ -571,7 +571,8 @@ export class MapInfo {
                     this.hp === mapStatistics.hp ? "" : ` (${mapStatistics.hp})`
                 }`;
             case 3: {
-                const maxScore: number = this.maxScore(mapStatistics);
+                const maxScore: number =
+                    this.map?.maxDroidScore(mapStatistics) ?? 0;
                 const convertedBPM: number = this.convertBPM(mapStatistics);
                 let string = "**BPM**: ";
                 if (this.map) {
@@ -695,15 +696,6 @@ export class MapInfo {
             default:
                 return 0;
         }
-    }
-
-    /**
-     * Calculates the osu!droid maximum score of the beatmap without taking spinner bonus into account.
-     *
-     * This requires .osu file to be downloaded.
-     */
-    maxScore(stats: MapStats): number {
-        return this.map?.maxDroidScore(stats) ?? 0;
     }
 
     /**

--- a/packages/osu-base/tests/beatmap/Beatmap.test.ts
+++ b/packages/osu-base/tests/beatmap/Beatmap.test.ts
@@ -2,6 +2,8 @@ import {
     Beatmap,
     Circle,
     DifficultyControlPoint,
+    MapStats,
+    ModHidden,
     objectTypes,
     PathType,
     Slider,
@@ -225,4 +227,46 @@ test("Test max combo getter", () => {
     ++beatmap.spinners;
 
     expect(beatmap.maxCombo).toBe(5);
+});
+
+test("Test osu!droid max score calculation", () => {
+    const beatmap = new Beatmap();
+
+    const stats = new MapStats();
+
+    expect(beatmap.maxDroidScore(stats)).toBe(0);
+
+    beatmap.objects.push(
+        new Circle({
+            startTime: 1000,
+            position: new Vector2(0, 0),
+        })
+    );
+
+    ++beatmap.circles;
+
+    expect(beatmap.maxDroidScore(stats)).toBe(300);
+
+    stats.mods.push(new ModHidden());
+
+    expect(beatmap.maxDroidScore(stats)).toBeCloseTo(300 * 1.06);
+});
+
+test("Test osu!standard max score calculation", () => {
+    const beatmap = new Beatmap();
+
+    expect(beatmap.maxOsuScore()).toBe(0);
+
+    beatmap.objects.push(
+        new Circle({
+            startTime: 1000,
+            position: new Vector2(0, 0),
+        })
+    );
+
+    ++beatmap.circles;
+
+    expect(beatmap.maxOsuScore()).toBe(300);
+
+    expect(beatmap.maxOsuScore([new ModHidden()])).toBeCloseTo(300 * 1.06);
 });

--- a/packages/osu-base/tests/beatmap/Beatmap.test.ts
+++ b/packages/osu-base/tests/beatmap/Beatmap.test.ts
@@ -249,7 +249,7 @@ test("Test osu!droid max score calculation", () => {
 
     stats.mods.push(new ModHidden());
 
-    expect(beatmap.maxDroidScore(stats)).toBeCloseTo(300 * 1.06);
+    expect(beatmap.maxDroidScore(stats)).toBeCloseTo(300);
 });
 
 test("Test osu!standard max score calculation", () => {
@@ -268,5 +268,5 @@ test("Test osu!standard max score calculation", () => {
 
     expect(beatmap.maxOsuScore()).toBe(300);
 
-    expect(beatmap.maxOsuScore([new ModHidden()])).toBeCloseTo(300 * 1.06);
+    expect(beatmap.maxOsuScore([new ModHidden()])).toBeCloseTo(300);
 });

--- a/packages/osu-base/tests/tools/MapInfo.test.ts
+++ b/packages/osu-base/tests/tools/MapInfo.test.ts
@@ -401,9 +401,3 @@ test("Test status color", () => {
 
     expect(beatmapInfo.statusColor).toBe(16711796);
 });
-
-test("Test maximum score calculator", () => {
-    const beatmapInfo = new MapInfo();
-
-    expect(beatmapInfo.maxScore(new MapStats())).toBe(0);
-});

--- a/packages/osu-base/typings/index.d.ts
+++ b/packages/osu-base/typings/index.d.ts
@@ -573,12 +573,6 @@ declare module "@rian8337/osu-base" {
          */
         get statusColor(): number;
         /**
-         * Calculates the osu!droid maximum score of the beatmap without taking spinner bonus into account.
-         *
-         * This requires .osu file to be downloaded.
-         */
-        maxScore(stats: MapStats): number;
-        /**
          * Returns a string representative of the class.
          */
         toString(): string;

--- a/packages/osu-base/typings/index.d.ts
+++ b/packages/osu-base/typings/index.d.ts
@@ -170,7 +170,7 @@ declare module "@rian8337/osu-base" {
          *
          * @param mods The modifications to calculate for. Defaults to No Mod.
          */
-        maxOsuScore(mods: Mod[] = []): number;
+        maxOsuScore(mods?: Mod[]): number;
         /**
          * Calculates the maximum score with a given difficulty and score multiplier.
          *


### PR DESCRIPTION
This method requires `<MapInfo>.map` to be defined and it'd be more flexible to have this method at `Beatmap` level instead.