### PR TITLE
Updated README's "map" -> "beatmap"

### DIFF
--- a/packages/osu-base/README.md
+++ b/packages/osu-base/README.md
@@ -136,7 +136,7 @@ if (!beatmapInfo.title) {
 }
 
 // Decoded beatmap can be accessed via the `map` field
-console.log(beatmapInfo.map);
+console.log(beatmapInfo.beatmap);
 ```
 
 #### Not retrieving beatmap file

--- a/packages/osu-base/README.md
+++ b/packages/osu-base/README.md
@@ -135,7 +135,7 @@ if (!beatmapInfo.title) {
     return console.log("Beatmap not found");
 }
 
-// Decoded beatmap can be accessed via the `map` field
+// Decoded beatmap can be accessed via the `beatmap` field
 console.log(beatmapInfo.beatmap);
 ```
 

--- a/packages/osu-difficulty-calculator/README.md
+++ b/packages/osu-difficulty-calculator/README.md
@@ -43,17 +43,17 @@ if (!beatmapInfo.title) {
 }
 
 // Calculate osu!droid difficulty
-const droidRating = new DroidDifficultyCalculator(beatmapInfo.map).calculate();
+const droidRating = new DroidDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 console.log(droidRating);
 
 // Calculate osu!standard difficulty
-const osuRating = new OsuDifficultyCalculator(beatmapInfo.map).calculate();
+const osuRating = new OsuDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 console.log(osuRating);
 
 // Calculate both osu!droid and osu!standard difficulty
-const rating = new MapStars(beatmapInfo.map);
+const rating = new MapStars(beatmapInfo.beatmap);
 
 // osu!droid difficulty
 console.log(rating.droid);
@@ -87,7 +87,7 @@ const stats = new MapStats({
 });
 
 // Also available in `DroidDifficultyCalculator` and `OsuDifficultyCalculator` as a parameter of `calculate`
-const rating = new MapStars(beatmapInfo.map, {
+const rating = new MapStars(beatmapInfo.beatmap, {
     mods: mods,
     stats: stats,
 });
@@ -114,7 +114,7 @@ if (!beatmapInfo.title) {
     return console.log("Beatmap not found");
 }
 
-const rating = new MapStars(beatmapInfo.map);
+const rating = new MapStars(beatmapInfo.beatmap);
 
 // osu!droid performance
 const droidPerformance = new DroidPerformanceCalculator(
@@ -154,7 +154,7 @@ if (!beatmapInfo.title) {
     return console.log("Beatmap not found");
 }
 
-const rating = new OsuDifficultyCalculator(beatmapInfo.map).calculate();
+const rating = new OsuDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 const accuracy = new Accuracy({
     // Specify your misses here

--- a/packages/osu-droid-replay-analyzer/README.md
+++ b/packages/osu-droid-replay-analyzer/README.md
@@ -53,7 +53,7 @@ if (!beatmapInfo.title) {
 // A `ReplayAnalyzer` instance that contains the replay
 const replay = await new ReplayAnalyzer({
     scoreID: 12948732,
-    map: beatmapInfo.map,
+    map: beatmapInfo.beatmap,
 }).analyze();
 
 // The data of the replay
@@ -85,7 +85,7 @@ readFile("path/to/file.odr", async (err, replayData) => {
     }
 
     // A `ReplayAnalyzer` instance that contains the replay
-    const replay = new ReplayAnalyzer({ scoreID: 0, map: beatmapInfo.map });
+    const replay = new ReplayAnalyzer({ scoreID: 0, map: beatmapInfo.beatmap });
 
     replay.originalODR = replayData;
 
@@ -128,7 +128,7 @@ if (!beatmapInfo.title) {
 // A `ReplayAnalyzer` instance that contains the replay
 const replay = await new ReplayAnalyzer({
     scoreID: 12948732,
-    map: beatmapInfo.map,
+    map: beatmapInfo.beatmap,
 }).analyze();
 
 // The data of the replay
@@ -148,7 +148,7 @@ const stats = new MapStats({
 });
 
 replay.map = new DroidStarRating().calculate({
-    map: beatmapInfo.map,
+    map: beatmapInfo.beatmap,
     mods: data.convertedMods,
     stats: stats,
 });

--- a/packages/osu-rebalance-difficulty-calculator/README.md
+++ b/packages/osu-rebalance-difficulty-calculator/README.md
@@ -43,17 +43,17 @@ if (!beatmapInfo.title) {
 }
 
 // Calculate osu!droid difficulty
-const droidRating = new DroidDifficultyCalculator(beatmapInfo.map).calculate();
+const droidRating = new DroidDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 console.log(droidRating);
 
 // Calculate osu!standard difficulty
-const osuRating = new OsuDifficultyCalculator(beatmapInfo.map).calculate();
+const osuRating = new OsuDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 console.log(osuRating);
 
 // Calculate both osu!droid and osu!standard difficulty
-const rating = new MapStars(beatmapInfo.map);
+const rating = new MapStars(beatmapInfo.beatmap);
 
 // osu!droid difficulty
 console.log(rating.droid);
@@ -87,7 +87,7 @@ const stats = new MapStats({
 });
 
 // Also available in `DroidDifficultyCalculator` and `OsuDifficultyCalculator` as a parameter of `calculate`
-const rating = new MapStars(beatmapInfo.map, {
+const rating = new MapStars(beatmapInfo.beatmap, {
     mods: mods,
     stats: stats,
 });
@@ -114,7 +114,7 @@ if (!beatmapInfo.title) {
     return console.log("Beatmap not found");
 }
 
-const rating = new MapStars(beatmapInfo.map);
+const rating = new MapStars(beatmapInfo.beatmap);
 
 // osu!droid performance
 const droidPerformance = new DroidPerformanceCalculator(
@@ -154,7 +154,7 @@ if (!beatmapInfo.title) {
     return console.log("Beatmap not found");
 }
 
-const rating = new OsuDifficultyCalculator(beatmapInfo.map).calculate();
+const rating = new OsuDifficultyCalculator(beatmapInfo.beatmap).calculate();
 
 const accuracy = new Accuracy({
     // Specify your misses here

--- a/packages/osu-strain-graph-generator/README.md
+++ b/packages/osu-strain-graph-generator/README.md
@@ -41,7 +41,7 @@ import { default as getStrainChart } from "@rian8337/osu-strain-graph-generator"
     }
 
     const rating = new OsuStarRating().calculate({
-        map: beatmapInfo.map,
+        map: beatmapInfo.beatmap,
     });
 
     const chart = await getStrainChart(rating);


### PR DESCRIPTION
## Description
When I tried to use the package for difficulty calculation, I followed the example code in the README. It seems like the object "map" has been renamed to "beatmap".  I'm currently using osu! API v1

### Old
```ts
const beatmapInfo = await MapInfo.getInformation(901854);

if (!beatmapInfo.title) {
    return console.log("Beatmap not found");
}

const rating = new MapStars(beatmapInfo.map);
```
### New
```ts
const beatmapInfo = await MapInfo.getInformation(901854);

if (!beatmapInfo.title) {
    return console.log("Beatmap not found");
}

const rating = new MapStars(beatmapInfo.beatmap);
```

I'm hoping this change can help new users not encounter the same error I had. Overall, this package has been amazing to use. Thank you Rian ✨ 